### PR TITLE
bug:oidToByteString

### DIFF
--- a/agentcontrolSubAgent.go
+++ b/agentcontrolSubAgent.go
@@ -24,6 +24,15 @@ type SubAgent struct {
 }
 
 func (t *SubAgent) SyncConfig() error {
+	var (
+		err error
+	)
+	for _, oid := range t.OIDs {
+		err = IsValidObjectIdentifier(oid.OID)
+		if err != nil {
+			return err
+		}
+	}
 	sort.Sort(byOID(t.OIDs))
 	t.Logger.Infof("Total OIDs of %v: %v", t.CommunityIDs, len(t.OIDs))
 	for id, each := range t.OIDs {
@@ -441,8 +450,6 @@ func (t *SubAgent) serveSetRequest(i *gosnmp.SnmpPacket) (*gosnmp.SnmpPacket, er
 	return &ret, nil
 }
 
-// getForPDUValueControl
-// FIX BUG:
 func (t *SubAgent) getForPDUValueControl(oid string) (*PDUValueControlItem, int) {
 	toQuery := oidToByteString(oid)
 	i := sort.Search(len(t.OIDs), func(i int) bool {

--- a/agentcontrolSubAgent.go
+++ b/agentcontrolSubAgent.go
@@ -441,6 +441,8 @@ func (t *SubAgent) serveSetRequest(i *gosnmp.SnmpPacket) (*gosnmp.SnmpPacket, er
 	return &ret, nil
 }
 
+// getForPDUValueControl
+// FIX BUG:
 func (t *SubAgent) getForPDUValueControl(oid string) (*PDUValueControlItem, int) {
 	toQuery := oidToByteString(oid)
 	i := sort.Search(len(t.OIDs), func(i int) bool {

--- a/agentcontrolSubAgent.go
+++ b/agentcontrolSubAgent.go
@@ -449,16 +449,14 @@ func (t *SubAgent) serveSetRequest(i *gosnmp.SnmpPacket) (*gosnmp.SnmpPacket, er
 }
 
 func (t *SubAgent) getForPDUValueControl(oid string) (*PDUValueControlItem, int) {
-	toQuery := oidToByteString(oid)
+	// todo: maybe we can implement add "." at other place.
+	toQuery := "." + oidToByteString(oid)
 	i := sort.Search(len(t.OIDs), func(i int) bool {
 		thisOid := oidToByteString(t.OIDs[i].OID)
 		return thisOid >= toQuery
 	})
-	if i < len(t.OIDs) {
-		thisOid := oidToByteString(t.OIDs[i].OID)
-		if thisOid == toQuery {
-			return t.OIDs[i], i
-		}
+	if i < len(t.OIDs) && oidToByteString(t.OIDs[i].OID) == toQuery {
+		return t.OIDs[i], i
 	}
 	return nil, i
 }

--- a/agentcontrolSubAgent.go
+++ b/agentcontrolSubAgent.go
@@ -28,19 +28,17 @@ func (t *SubAgent) SyncConfig() error {
 		err error
 	)
 	for _, oid := range t.OIDs {
-		err = IsValidObjectIdentifier(oid.OID)
-		if err != nil {
+		if err = VerifyOid(oid.OID); err != nil {
 			return err
 		}
 	}
+	t.Logger.Debugf("Total OIDs of %v: %v", t.CommunityIDs, len(t.OIDs))
+
 	sort.Sort(byOID(t.OIDs))
-	t.Logger.Infof("Total OIDs of %v: %v", t.CommunityIDs, len(t.OIDs))
 	for id, each := range t.OIDs {
 		t.Logger.Infof("OIDs of %v: %v", t.CommunityIDs, each.OID)
 		if id != 0 && t.OIDs[id].OID == t.OIDs[id-1].OID {
-			verr := fmt.Sprintf("community %v: meet duplicate oid %v", t.CommunityIDs, each.OID)
-			t.Logger.Errorf(verr)
-			return errors.New(verr)
+			return fmt.Errorf("community %v: meet duplicate oid %v", t.CommunityIDs, each.OID)
 		}
 	}
 	return nil

--- a/go.sum
+++ b/go.sum
@@ -8,7 +8,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
 github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
-github.com/golang/mock v1.2.0 h1:28o5sBqPkBsMGnC6b4MvE2TzSr5/AT4c/1fLqVGIwlk=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -30,7 +29,6 @@ github.com/slayercat/gosnmp v1.24.1 h1:brqlcYbSEa5tESH+Dwo82Nm4Hnzt4pk1kTQ6Sxcl6
 github.com/slayercat/gosnmp v1.24.1/go.mod h1:EEciH24gj0Z8lijV/NUrlAZ8D1TYHImV0cvLMsUpRmM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.1-0.20200129000828-ea72eb91592e h1:diXFpsm7FZhZyMG+JS7uuehk3SmDKD8vfP6y8Jb9zMQ=
 github.com/stretchr/testify v1.4.1-0.20200129000828-ea72eb91592e/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
@@ -42,7 +40,6 @@ golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9 h1:1/DFK4b7JH8DmkqhUk48onnSf
 golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/helpers.go
+++ b/helpers.go
@@ -1,9 +1,6 @@
 package GoSNMPServer
 
-import "github.com/pkg/errors"
 import "github.com/slayercat/gosnmp"
-import "strings"
-import "strconv"
 
 func getPktContextOrCommunity(i *gosnmp.SnmpPacket) string {
 	if i.Version == gosnmp.Version3 {
@@ -21,25 +18,11 @@ func copySnmpPacket(i *gosnmp.SnmpPacket) gosnmp.SnmpPacket {
 	return ret
 }
 
+// Fix BUG: When converting certain byte values to the rune type,
+// some byte values may not be represented correctly because the rune type represents a Unicode character.
+// This can cause byte values to become unpredictable or incorrect after conversion.
 func oidToByteString(oid string) string {
-	xi := strings.Split(oid, ".")
-	out := []rune{}
-	for id, each := range xi {
-		if each == "" {
-			if id == 0 {
-				continue
-			} else {
-				panic(errors.Errorf("oidToByteString not valid id. value=%v", oid))
-			}
-
-		}
-		i, err := strconv.ParseInt(each, 10, 32)
-		if err != nil {
-			panic(err)
-		}
-		out = append(out, rune(i))
-	}
-	return string(out)
+	return oid
 }
 
 // IsValidObjectIdentifier will check a oid string is valid oid

--- a/helpers.go
+++ b/helpers.go
@@ -47,7 +47,7 @@ func IsValidObjectIdentifier(oid string) (result bool) {
 }
 
 // VerifyOid will check an oid string is valid oid,
-// each number should be positive int32.
+// each number should be positive uint32.
 func VerifyOid(oid string) error {
 	xi := strings.Split(oid, ".")
 	for id, each := range xi {

--- a/helpers.go
+++ b/helpers.go
@@ -57,7 +57,7 @@ func VerifyOid(oid string) error {
 			}
 			return errors.New("oidToByteString not valid int,but it is empty " + oid)
 		}
-		i, err := strconv.ParseInt(each, 10, 32)
+		i, err := strconv.ParseUint(each, 10, 32)
 		if err != nil {
 			return errors.New("oidToByteString not valid int. value=" + each)
 		} else if i < 0 {

--- a/helpers.go
+++ b/helpers.go
@@ -1,6 +1,11 @@
 package GoSNMPServer
 
-import "github.com/slayercat/gosnmp"
+import (
+	"github.com/pkg/errors"
+	"github.com/slayercat/gosnmp"
+	"strconv"
+	"strings"
+)
 
 func getPktContextOrCommunity(i *gosnmp.SnmpPacket) string {
 	if i.Version == gosnmp.Version3 {
@@ -26,16 +31,20 @@ func oidToByteString(oid string) string {
 }
 
 // IsValidObjectIdentifier will check a oid string is valid oid
-func IsValidObjectIdentifier(oid string) (result bool) {
-	defer func() {
-		if err := recover(); err != nil {
-			result = false
-			return
+func IsValidObjectIdentifier(oid string) error {
+	xi := strings.Split(oid, ".")
+	for id, each := range xi {
+		if each == "" {
+			if id == 0 {
+				continue
+			} else {
+				return errors.Errorf("oidToByteString not valid id. value=%v", oid)
+			}
 		}
-	}()
-	if len(oid) == 0 {
-		return false
+		i, err := strconv.ParseInt(each, 10, 32)
+		if err != nil || i < 0 {
+			return errors.Errorf("oidToByteString not valid id. value=%v", oid)
+		}
 	}
-	oidToByteString(oid)
-	return true
+	return nil
 }

--- a/helpers.go
+++ b/helpers.go
@@ -30,7 +30,7 @@ func oidToByteString(oid string) string {
 	return oid
 }
 
-// IsValidObjectIdentifier will check a oid string is valid oid
+// IsValidObjectIdentifier will check an oid string is valid oid
 // Deprecated: instead use VerifyOid.
 func IsValidObjectIdentifier(oid string) (result bool) {
 	defer func() {
@@ -46,6 +46,8 @@ func IsValidObjectIdentifier(oid string) (result bool) {
 	return true
 }
 
+// VerifyOid will check an oid string is valid oid,
+// each number should be positive int32.
 func VerifyOid(oid string) error {
 	xi := strings.Split(oid, ".")
 	for id, each := range xi {

--- a/helpers.go
+++ b/helpers.go
@@ -31,19 +31,35 @@ func oidToByteString(oid string) string {
 }
 
 // IsValidObjectIdentifier will check a oid string is valid oid
-func IsValidObjectIdentifier(oid string) error {
+// Deprecated: instead use VerifyOid.
+func IsValidObjectIdentifier(oid string) (result bool) {
+	defer func() {
+		if err := recover(); err != nil {
+			result = false
+			return
+		}
+	}()
+	if len(oid) == 0 {
+		return false
+	}
+	oidToByteString(oid)
+	return true
+}
+
+func VerifyOid(oid string) error {
 	xi := strings.Split(oid, ".")
 	for id, each := range xi {
 		if each == "" {
 			if id == 0 {
 				continue
-			} else {
-				return errors.Errorf("oidToByteString not valid id. value=%v", oid)
 			}
+			return errors.New("oidToByteString not valid int,but it is empty " + oid)
 		}
 		i, err := strconv.ParseInt(each, 10, 32)
-		if err != nil || i < 0 {
-			return errors.Errorf("oidToByteString not valid id. value=%v", oid)
+		if err != nil {
+			return errors.New("oidToByteString not valid int. value=" + each)
+		} else if i < 0 {
+			return errors.New("oidToByteString not valid int. value=" + each + " should be positive")
 		}
 	}
 	return nil

--- a/pducontrol.go
+++ b/pducontrol.go
@@ -16,19 +16,21 @@ const PermissionAllowanceAllowed PermissionAllowance = 0
 // PermissionAllowanceDenied denies for access
 const PermissionAllowanceDenied PermissionAllowance = 1
 
-//FuncPDUControlCheckPermission checks for permission.
-//   return PermissionAllowanceAllowed / PermissionAllowanceDenied
+// FuncPDUControlCheckPermission checks for permission.
+//
+//	return PermissionAllowanceAllowed / PermissionAllowanceDenied
 type FuncPDUControlCheckPermission func(pktVersion gosnmp.SnmpVersion, pduType gosnmp.PDUType, contextName string) PermissionAllowance
 
-//FuncPDUControlTrap will be called on trap.
-//    args:
-//		isInform: indicate if the request is a InformRequest.
-//          true  -- It's a InformRequest. data will be returns to the client
-//			false -- It's a trap.  data to returned will drop silencely.
-// 		trapdata: what client asks for.
-//    returns:
-//		dataret -- try to return to client. nil for nothing to return
-//		err  --  any error?(will return to client by string)
+// FuncPDUControlTrap will be called on trap.
+//
+//	   args:
+//			isInform: indicate if the request is a InformRequest.
+//	         true  -- It's a InformRequest. data will be returns to the client
+//				false -- It's a trap.  data to returned will drop silencely.
+//			trapdata: what client asks for.
+//	   returns:
+//			dataret -- try to return to client. nil for nothing to return
+//			err  --  any error?(will return to client by string)
 type FuncPDUControlTrap func(isInform bool, trapdata gosnmp.SnmpPDU) (dataret interface{}, err error)
 
 // FuncPDUControlGet will be called on get value
@@ -123,9 +125,7 @@ func (x byOID) Len() int {
 }
 
 func (x byOID) Less(i, j int) bool {
-	stripedI := oidToByteString(x[i].OID)
-	stripedJ := oidToByteString(x[j].OID)
-	return stripedI < stripedJ
+	return oidToByteString(x[i].OID) < oidToByteString(x[j].OID)
 }
 
 func (x byOID) Swap(i, j int) {


### PR DESCRIPTION
1. When converting certain byte values ​​to the rune type, some byte values ​​may not be represented correctly because the rune type represents a Unicode character. This can cause byte values ​​to become unpredictable or incorrect after conversion.
2. Each time a new request is received, such as Get, Get-Next, it will perform multiple oidToByteString operations, there is additional cpu overhead，but this is not necessary.
3. If it is to verify the legitimacy of the OID, is it more appropriate to only perform the verification in SyncConfig, not when subsequent new requests flow in?