### PR TITLE
Correct laLoadInt 1/5/15 min CPU load average values

### DIFF
--- a/mibImps/ucdMib/loadAvg.go
+++ b/mibImps/ucdMib/loadAvg.go
@@ -44,7 +44,7 @@ func SystemLoadOIDs() []*GoSNMPServer.PDUValueControlItem {
 				if val, err := load.Avg(); err != nil {
 					return nil, err
 				} else {
-					return GoSNMPServer.Asn1IntegerWrap(int(val.Load1)), nil
+					return GoSNMPServer.Asn1IntegerWrap(int(val.Load1 * 100)), nil
 				}
 			},
 			Document: "laLoadInt",
@@ -81,7 +81,7 @@ func SystemLoadOIDs() []*GoSNMPServer.PDUValueControlItem {
 				if val, err := load.Avg(); err != nil {
 					return nil, err
 				} else {
-					return GoSNMPServer.Asn1IntegerWrap(int(val.Load5)), nil
+					return GoSNMPServer.Asn1IntegerWrap(int(val.Load5 * 100)), nil
 				}
 			},
 			Document: "laLoadInt",
@@ -118,7 +118,7 @@ func SystemLoadOIDs() []*GoSNMPServer.PDUValueControlItem {
 				if val, err := load.Avg(); err != nil {
 					return nil, err
 				} else {
-					return GoSNMPServer.Asn1IntegerWrap(int(val.Load15)), nil
+					return GoSNMPServer.Asn1IntegerWrap(int(val.Load15 * 100)), nil
 				}
 			},
 			Document: "laLoadInt",


### PR DESCRIPTION
The built-in laLoadInt (1.3.6.1.4.1.2021.10.1.5.{1,2,3}) OIDs from ucdMib/loadAvg.go are returning incorrect values.

- https://oidref.com/1.3.6.1.4.1.2021.10.1.5
- The values represent the floating point loadaverage value multiplied by 100, then converted  to an integer"

I'm not quite sure how to handle the rounding, but I think the result with this very simple change is sufficient, and the OIDs will now return usable values. Currently, with CPU usage less than 50% of a single core, the values will show 0.