### PR TITLE
the SubAgent OIDs are threadsafe and linked

### DIFF
--- a/pducontrol.go
+++ b/pducontrol.go
@@ -68,6 +68,9 @@ type PDUValueControlItem struct {
 
 	//Document for this PDU Item. ignored by the program.
 	Document string
+
+	nextPDU *PDUValueControlItem
+	id      int
 }
 
 func Asn1IntegerUnwrap(i interface{}) int { return i.(int) }


### PR DESCRIPTION
The SubAgent OIDs are now thread safe so generator functions could update them dynamically. Also the OIDs are in a linked list so 'nextPDU' functions can relatively resolve.