### PR TITLE
fix for next on bulkrequest

### DIFF
--- a/agentcontrolSubAgent.go
+++ b/agentcontrolSubAgent.go
@@ -314,17 +314,14 @@ func (t *SubAgent) serveGetBulkRequest(i *gosnmp.SnmpPacket) (*gosnmp.SnmpPacket
 
 	t.Logger.Debugf("handle remaining (%d, max-repetitions=%d)", vc-i.NonRepeaters, i.MaxRepetitions)
 	eomv := make(map[string]struct{})
+	lastItem := &PDUValueControlItem{OID: i.Variables[0].Name}
 	for j := uint32(0); j < i.MaxRepetitions; j++ { // loop through repetitions
 		for k := i.NonRepeaters; k < vc; k++ { // loop through "repeaters"
 			queryForOid := i.Variables[k].Name
 			queryForOidStriped := strings.TrimLeft(queryForOid, ".0")
 			item, before := t.getForPDUValueControl(queryForOidStriped)
-
 			if !before {
 				item = t.NextPDU(item, 0)
-				if item == nil {
-					break
-				}
 			} else {
 				before = false
 			}
@@ -335,17 +332,17 @@ func (t *SubAgent) serveGetBulkRequest(i *gosnmp.SnmpPacket) (*gosnmp.SnmpPacket
 
 			if item == nil {
 				if _, found := eomv[queryForOid]; !found {
-					ret.Variables = append(ret.Variables, t.getPDUEndOfMibView(queryForOid))
+					ret.Variables = append(ret.Variables, t.getPDUEndOfMibView(lastItem.OID))
 					eomv[queryForOid] = struct{}{}
 				}
-				continue
+				return &ret, nil
 			}
-			t.Logger.Debugf("t.getForPDUValueControl. query_for_oid=%v item=%v id=%v", queryForOid, item, item.id)
 			ctl, snmperr := t.getForPDUValueControlResult(item, i)
 			if snmperr != gosnmp.NoError && ret.Error == gosnmp.NoError {
 				ret.Error = snmperr
 				ret.ErrorIndex = k
 			}
+			lastItem = item
 			ret.Variables = append(ret.Variables, ctl)
 		}
 	}
@@ -487,8 +484,12 @@ func (t *SubAgent) getForPDUValueControl(oid string) (*PDUValueControlItem, bool
 
 	if i < len(t.OIDs) {
 		// t.OIDs[i].OID == toQuery
-		if compareByteString(oidToByteString(t.OIDs[i].OID), toQuery) == ByteStringCompareResultEqual {
+		compareResult := compareByteString(oidToByteString(t.OIDs[i].OID), toQuery)
+		switch compareResult {
+		case ByteStringCompareResultEqual:
 			return t.OIDs[i], false
+		case ByteStringCompareResultGreaterThen:
+			return t.OIDs[i], true
 		}
 	}
 
@@ -507,7 +508,6 @@ func (t *SubAgent) NextPDU(item *PDUValueControlItem, skip int) *PDUValueControl
 }
 
 func (t *SubAgent) nextPDU(item *PDUValueControlItem, skip int) *PDUValueControlItem {
-
 	if item == nil || item.nextPDU == nil {
 		return nil
 	}

--- a/snmpserver_test.go
+++ b/snmpserver_test.go
@@ -410,14 +410,32 @@ func (suite *ServerTests) TestGetSetOids() {
 
 	})
 	suite.Run("SNMPBulkGet", func() {
-		result, err := getCmdOutput("snmpbulkwalk", "-v2c", "-c", "public", serverAddress.String(),
+		result, err := getCmdOutput("snmpbulkwalk", "-v2c", "-c", "public", "-On", serverAddress.String(),
 			"1")
 		if err != nil {
 			suite.T().Errorf("cmd meet error: %+v.\nresultErr=%v\n resultout=%v",
 				err, string(err.(*exec.ExitError).Stderr), string(result))
 		}
 		lines := bytes.Split(bytes.TrimSpace(result), []byte("\n"))
+		suite.T().Logf("result: %v", string(result))
 		assert.Equalf(suite.T(), len(master.SubAgents[0].OIDs)+1, len(lines), "data snmpwalk gets: \n%v", string(result))
+		assert.Equalf(suite.T(),
+			".1.2.4.2.0 = No more variables left in this MIB View (It is past the end of the MIB tree)",
+			string(lines[len(lines)-1]), "data snmpwalk gets: \n%v", string(lines[len(lines)-1]))
+	})
+	suite.Run("SNMPBulkGetLexicalNext", func() {
+		result, err := getCmdOutput("snmpbulkwalk", "-v2c", "-c", "public", "-On", serverAddress.String(),
+			"1.2.4.2")
+		if err != nil {
+			suite.T().Errorf("cmd meet error: %+v.\nresultErr=%v\n resultout=%v",
+				err, string(err.(*exec.ExitError).Stderr), string(result))
+		}
+		lines := bytes.Split(bytes.TrimSpace(result), []byte("\n"))
+		suite.T().Logf("result: %v", string(result))
+		assert.Equalf(suite.T(), 1+1, len(lines), "data snmpwalk gets: \n%v", string(result))
+		assert.Equalf(suite.T(),
+			".1.2.4.2.0 = No more variables left in this MIB View (It is past the end of the MIB tree)",
+			string(lines[1]), "data snmpwalk gets: \n%v", string(lines[1]))
 	})
 	suite.Run("SNMPWalk_UnknownUser", func() {
 		result, err := getCmdOutput("snmpwalk", "-v3", "-n", "public", "-u", "UnknownUser",
@@ -600,6 +618,19 @@ func (suite *ServerTests) getTestGetSetOIDS() []*PDUValueControlItem {
 				return nil
 			},
 			Document: "TestTypeIPAddress",
+		},
+		{
+			OID:  "1.2.4.2.0",
+			Type: gosnmp.Counter32,
+			OnGet: func() (value interface{}, err error) {
+				return Asn1Gauge32Wrap(baseTestSuite.privGetSetOIDS.val_Gauge32), nil
+			},
+			OnSet: func(value interface{}) (err error) {
+				val := Asn1Gauge32Unwrap(baseTestSuite.privGetSetOIDS.val_Gauge32)
+				baseTestSuite.privGetSetOIDS.val_Gauge32 = val
+				return nil
+			},
+			Document: "TestTypeScalarCounter32",
 		},
 	}
 }


### PR DESCRIPTION
A request via a bulkrequest on a parent node of a scalar returned nothing wit the latest changes.
This change fixes this and the scalar is returned.

e.g.

scalar oid is 1.2.3.4.0 and Bulk is requesting 1.2.3.4 it now returns 1.2.3.4.0
